### PR TITLE
make file globs compatible with rules_docker's py3_image()

### DIFF
--- a/pyenv/defs.bzl
+++ b/pyenv/defs.bzl
@@ -39,14 +39,14 @@ exports_files([
 
 py_runtime(
     name = "python_{py2}_runtime",
-    files = glob(["versions/{py2}/**/*"], exclude_directories = 0),
+    files = glob(["versions/{py2}/**/*"], exclude_directories = 1, exclude = ["**/* *"]),
     interpreter = "versions/{py2}/{interpreter_path}",
     python_version = "PY2"
 )
 
 py_runtime(
     name = "python_{py3}_runtime",
-    files = glob(["versions/{py3}/**/*"], exclude_directories = 0),
+    files = glob(["versions/{py3}/**/*"], exclude_directories = 1, exclude = ["**/* *"]),
     interpreter = "versions/{py3}/{interpreter_path}",
     python_version = "PY3"
 )
@@ -72,7 +72,7 @@ exports_files([
 
 py_runtime(
     name = "python_{py3}_runtime",
-    files = glob(["versions/{py3}/**/*"], exclude_directories = 0),
+    files = glob(["versions/{py3}/**/*"], exclude_directories = 1, exclude = ["**/* *"]),
     interpreter = "versions/{py3}/{interpreter_path}",
     python_version = "PY3"
 )


### PR DESCRIPTION
There are 2 incompatibilities with the python install that pyenv creates:
* empty directories - bazel's sandbox mode + rules_pkg doesn't work with
  them: https://github.com/bazelbuild/rules_pkg/issues/135
* spaces in filenames - https://github.com/bazelbuild/bazel/issues/374

So pass flags to `glob()` to exclude these sticking points, and you can now build
a container (or tar) with rules_pyenv built python.